### PR TITLE
feat: add stock service

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -9,5 +9,5 @@
     "default": 10,
     "max": 50
   },
-  "mongodb": "mongodb://127.0.0.1:27017/lets-stock-backend"
+  "mongodb": "mongodb://root:example@127.0.0.1:27017/lets-stock-backend?authSource=admin"
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,6 +4,9 @@ import type { TransportConnection, Application } from '@feathersjs/feathers'
 import authenticationClient from '@feathersjs/authentication-client'
 import type { AuthenticationClientOptions } from '@feathersjs/authentication-client'
 
+import { stockClient } from './services/stock/stock.shared'
+export type { Stock, StockData, StockQuery, StockPatch } from './services/stock/stock.shared'
+
 export interface Configuration {
   connection: TransportConnection<ServiceTypes>
 }
@@ -30,5 +33,6 @@ export const createClient = <Configuration = any,>(
   client.configure(authenticationClient(authenticationOptions))
   client.set('connection', connection)
 
+  client.configure(stockClient)
   return client
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,6 +1,8 @@
+import { stock } from './stock/stock'
 // For more information about this file see https://dove.feathersjs.com/guides/cli/application.html#configure-functions
 import type { Application } from '../declarations'
 
 export const services = (app: Application) => {
+  app.configure(stock)
   // All services will be registered here
 }

--- a/src/services/stock/stock.class.ts
+++ b/src/services/stock/stock.class.ts
@@ -1,0 +1,26 @@
+// For more information about this file see https://dove.feathersjs.com/guides/cli/service.class.html#database-services
+import type { Params } from '@feathersjs/feathers'
+import { MongoDBService } from '@feathersjs/mongodb'
+import type { MongoDBAdapterParams, MongoDBAdapterOptions } from '@feathersjs/mongodb'
+
+import type { Application } from '../../declarations'
+import type { Stock, StockData, StockPatch, StockQuery } from './stock.schema'
+
+export type { Stock, StockData, StockPatch, StockQuery }
+
+export interface StockParams extends MongoDBAdapterParams<StockQuery> {}
+
+// By default calls the standard MongoDB adapter service methods but can be customized with your own functionality.
+export class StockService<ServiceParams extends Params = StockParams> extends MongoDBService<
+  Stock,
+  StockData,
+  StockParams,
+  StockPatch
+> {}
+
+export const getOptions = (app: Application): MongoDBAdapterOptions => {
+  return {
+    paginate: app.get('paginate'),
+    Model: app.get('mongodbClient').then((db) => db.collection('stock'))
+  }
+}

--- a/src/services/stock/stock.schema.ts
+++ b/src/services/stock/stock.schema.ts
@@ -1,0 +1,55 @@
+// // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
+import { resolve } from '@feathersjs/schema'
+import { Type, getValidator, querySyntax } from '@feathersjs/typebox'
+import { ObjectIdSchema } from '@feathersjs/typebox'
+import type { Static } from '@feathersjs/typebox'
+
+import type { HookContext } from '../../declarations'
+import { dataValidator, queryValidator } from '../../validators'
+import type { StockService } from './stock.class'
+
+// Main data model schema
+export const stockSchema = Type.Object(
+  {
+    _id: ObjectIdSchema(),
+    dateTime: Type.String({ format: 'date-time' }),
+    stockNum: Type.Number(),
+    stockCode: Type.String()
+  },
+  { $id: 'Stock', additionalProperties: false }
+)
+export type Stock = Static<typeof stockSchema>
+export const stockValidator = getValidator(stockSchema, dataValidator)
+export const stockResolver = resolve<Stock, HookContext<StockService>>({})
+
+export const stockExternalResolver = resolve<Stock, HookContext<StockService>>({})
+
+// Schema for creating new entries
+export const stockDataSchema = Type.Pick(stockSchema, ['dateTime', 'stockNum', 'stockCode'], {
+  $id: 'StockData'
+})
+export type StockData = Static<typeof stockDataSchema>
+export const stockDataValidator = getValidator(stockDataSchema, dataValidator)
+export const stockDataResolver = resolve<Stock, HookContext<StockService>>({})
+
+// Schema for updating existing entries
+export const stockPatchSchema = Type.Partial(stockSchema, {
+  $id: 'StockPatch'
+})
+export type StockPatch = Static<typeof stockPatchSchema>
+export const stockPatchValidator = getValidator(stockPatchSchema, dataValidator)
+export const stockPatchResolver = resolve<Stock, HookContext<StockService>>({})
+
+// Schema for allowed query properties
+export const stockQueryProperties = Type.Pick(stockSchema, ['_id', 'dateTime', 'stockCode'])
+export const stockQuerySchema = Type.Intersect(
+  [
+    querySyntax(stockQueryProperties),
+    // Add additional query properties here
+    Type.Object({}, { additionalProperties: false })
+  ],
+  { additionalProperties: false }
+)
+export type StockQuery = Static<typeof stockQuerySchema>
+export const stockQueryValidator = getValidator(stockQuerySchema, queryValidator)
+export const stockQueryResolver = resolve<StockQuery, HookContext<StockService>>({})

--- a/src/services/stock/stock.shared.ts
+++ b/src/services/stock/stock.shared.ts
@@ -1,0 +1,27 @@
+// For more information about this file see https://dove.feathersjs.com/guides/cli/service.shared.html
+import type { Params } from '@feathersjs/feathers'
+import type { ClientApplication } from '../../client'
+import type { Stock, StockData, StockPatch, StockQuery, StockService } from './stock.class'
+
+export type { Stock, StockData, StockPatch, StockQuery }
+
+export type StockClientService = Pick<StockService<Params<StockQuery>>, (typeof stockMethods)[number]>
+
+export const stockPath = 'stock'
+
+export const stockMethods = ['find', 'get', 'create', 'patch', 'remove'] as const
+
+export const stockClient = (client: ClientApplication) => {
+  const connection = client.get('connection')
+
+  client.use(stockPath, connection.service(stockPath), {
+    methods: stockMethods
+  })
+}
+
+// Add this service to the client service type index
+declare module '../../client' {
+  interface ServiceTypes {
+    [stockPath]: StockClientService
+  }
+}

--- a/src/services/stock/stock.ts
+++ b/src/services/stock/stock.ts
@@ -1,0 +1,59 @@
+// For more information about this file see https://dove.feathersjs.com/guides/cli/service.html
+
+import { hooks as schemaHooks } from '@feathersjs/schema'
+
+import {
+  stockDataValidator,
+  stockPatchValidator,
+  stockQueryValidator,
+  stockResolver,
+  stockExternalResolver,
+  stockDataResolver,
+  stockPatchResolver,
+  stockQueryResolver
+} from './stock.schema'
+
+import type { Application } from '../../declarations'
+import { StockService, getOptions } from './stock.class'
+import { stockPath, stockMethods } from './stock.shared'
+
+export * from './stock.class'
+export * from './stock.schema'
+
+// A configure function that registers the service and its hooks via `app.configure`
+export const stock = (app: Application) => {
+  // Register our service on the Feathers application
+  app.use(stockPath, new StockService(getOptions(app)), {
+    // A list of all methods this service exposes externally
+    methods: stockMethods,
+    // You can add additional custom events to be sent to clients here
+    events: []
+  })
+  // Initialize hooks
+  app.service(stockPath).hooks({
+    around: {
+      all: [schemaHooks.resolveExternal(stockExternalResolver), schemaHooks.resolveResult(stockResolver)]
+    },
+    before: {
+      all: [schemaHooks.validateQuery(stockQueryValidator), schemaHooks.resolveQuery(stockQueryResolver)],
+      find: [],
+      get: [],
+      create: [schemaHooks.validateData(stockDataValidator), schemaHooks.resolveData(stockDataResolver)],
+      patch: [schemaHooks.validateData(stockPatchValidator), schemaHooks.resolveData(stockPatchResolver)],
+      remove: []
+    },
+    after: {
+      all: []
+    },
+    error: {
+      all: []
+    }
+  })
+}
+
+// Add this service to the service type index
+declare module '../../declarations' {
+  interface ServiceTypes {
+    [stockPath]: StockService
+  }
+}

--- a/test/services/stock/stock.test.ts
+++ b/test/services/stock/stock.test.ts
@@ -1,0 +1,11 @@
+// For more information about this file see https://dove.feathersjs.com/guides/cli/service.test.html
+import assert from 'assert'
+import { app } from '../../../src/app'
+
+describe('stock service', () => {
+  it('registered the service', () => {
+    const service = app.service('stock')
+
+    assert.ok(service, 'Registered the service')
+  })
+})


### PR DESCRIPTION
- [x] manually add fake data in mongo in the database called "lets-stock-backend" and collection called "stock"
```
{
  "_id": {
    "$oid": "66062e3e7a863fc7920bee71"
  },
  "dateTime": { "$date": "2023-03-29T00:00:00Z" },
  "stockCode": "2330",
  "stockNum": 31
}
```

<img width="750" alt="image" src="https://github.com/allenyummy/lets-stock-backend/assets/36063123/c4de69fc-3950-4a9d-8dab-c8f6e4bc9513">

- [x] implement stock service (actually the more important part is to design the collection schema)
 
<img width="613" alt="image" src="https://github.com/allenyummy/lets-stock-backend/assets/36063123/d860bfd0-7d2c-4c0f-b57b-cc00dc06f375">
